### PR TITLE
Dockerfile and unicode fixes for hmac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM fedora:latest
+MAINTAINER "Laurent Rineau" <laurent.rineau@cgal.org>
+
+RUN yum -y update
+RUN yum -y install python-pip && yum clean all
+
+ADD LICENSE requirements.txt webhooks.py config.json hooks /src/
+
+RUN cd /src; pip install -r requirements.txt
+
+EXPOSE 5000
+
+WORKDIR /src
+CMD ["python", "/src/webhooks.py"]

--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,8 @@ executable and has a shebang. A simple example in Python could be:
         f.write(json.dumps(payload))
 
 
-Deploy
-======
+Deploy in Apache
+==================
 
 To deploy in Apache, just add a ``WSGIScriptAlias`` directive to your
 VirtualHost file:
@@ -126,6 +126,18 @@ And add a Webhook to the WSGI script URL:
 
    http://my.site.com/webhooks
 
+Deploy in a Docker container
+============================
+
+To deploy in a docker container, you have to expose the port 5000, for
+example with the following command:
+::
+    docker run -d --name webhooks -p 5000:5000 lrineau/python-github-webhooks
+
+You can also mount volume to setup the ``hooks/`` directory, and the file
+``config.json``:
+::
+    docker run -d --name webhooks -v /path/to/my/hooks:/src/hooks -v /path/to/my/config.json:/src/config.json -p 5000:5000 lrineau/python-github-webhooks
 
 Debug
 =====

--- a/README.rst
+++ b/README.rst
@@ -132,12 +132,12 @@ Deploy in a Docker container
 To deploy in a docker container, you have to expose the port 5000, for
 example with the following command:
 ::
-    docker run -d --name webhooks -p 5000:5000 lrineau/python-github-webhooks
+    docker run -d --name webhooks -p 5000:5000 cgal/python-github-webhooks
 
 You can also mount volume to setup the ``hooks/`` directory, and the file
 ``config.json``:
 ::
-    docker run -d --name webhooks -v /path/to/my/hooks:/src/hooks -v /path/to/my/config.json:/src/config.json -p 5000:5000 lrineau/python-github-webhooks
+    docker run -d --name webhooks -v /path/to/my/hooks:/src/hooks -v /path/to/my/config.json:/src/config.json -p 5000:5000 cgal/python-github-webhooks
 
 Debug
 =====

--- a/webhooks.py
+++ b/webhooks.py
@@ -74,8 +74,8 @@ def index():
             abort(501)
 
         # HMAC requires the key to be bytes, but data is string
-        mac = hmac.new(secret, msg=request.data, digestmod=sha1)
-        if not hmac.compare_digest(mac.hexdigest(), signature):
+        mac = hmac.new(str(secret), msg=request.data, digestmod=sha1)
+        if not hmac.compare_digest(str(mac.hexdigest()), str(signature)):
             abort(403)
 
     # Implement ping


### PR DESCRIPTION
I am deploying the script `python-github-webhooks` in a Docker container running the last version of Fedora. For that I had to modify the files. My contribution:
- add a `Dockerfile`, plus a modification of the `README.rst`,
- fixes unicode issues with hmac, when the service is protected by a secret.
