### PR TITLE
Fix git clone link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Install
 
 ::
 
-    git clone git@github.com:carlos-jenkins/python-github-webhooks.git
+    git clone https://github.com/carlos-jenkins/python-github-webhooks.git
     cd python-github-webhooks
 
 


### PR DESCRIPTION
The link that was being used is usually the one used by people with repo access, see what happens here: 
<img width="571" alt="screen shot 2017-06-20 at 2 51 54 pm" src="https://user-images.githubusercontent.com/2008034/27353007-39c396d8-55c8-11e7-94f5-903e8b61c0a4.png">

I fixed the link so it can be copy and pasted by anyone without permission errors. 