### PR TITLE
Fix(webhooks.py): Fixes JSON parsing errors in Python 3

### DIFF
--- a/webhooks.py
+++ b/webhooks.py
@@ -99,7 +99,7 @@ def index():
 
     # Gather data
     try:
-        payload = loads(request.data)
+        payload = request.get_json()
     except:
         abort(400)
 
@@ -168,6 +168,8 @@ def index():
             stdout=PIPE, stderr=PIPE
         )
         stdout, stderr = proc.communicate()
+        stout = stout.decode('utf-8')
+        stderr = stderr.decode('utf-8')
 
         ran[basename(s)] = {
             'returncode': proc.returncode,


### PR DESCRIPTION
This commit fixes some errors caused by changes to Flask and the JSON
parsing libraries in Python 3.

The change to .get_json() fixes an error because the Flask request.data
is encoded as a bytestring in python3, and loads() only supports string
as a datatype. `loads(request.data.decode('utf-8'))` would be the
equivalent.

The change to str() the ran variable fixes an error because it is a
DICT, not a JSON object (at least in Python 3), and it doesn't need to
be converted.