### PR TITLE
style: add python shebang to webhooks.py

### DIFF
--- a/webhooks.py
+++ b/webhooks.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2014, 2015, 2016 Carlos Jenkins <carlos@jenkins.co.cr>


### PR DESCRIPTION
This allows for the script to be run with sh, bash, etc.

Marked as executable `chmod +x`