### PR TITLE
Makefile to build docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+docker-build-latest: docker-pull-deps
+	docker build -t carlos-jenkins/python-github-webhooks .
+
+docker-build-push: docker-build-latest
+	TAG=$$(date +%Y%m%d%H%M%S) ;\
+	docker tag carlos-jenkins/python-github-webhooks:latest carlos-jenkins/python-github-webhooks:$$TAG ; \
+	docker push carlos-jenkins/python-github-webhooks:$$TAG ; \
+	docker push carlos-jenkins/python-github-webhooks:latest ; \
+
+docker-pull-deps:
+	docker pull python:2.7-alpine
+
+all: docker-build-latest

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,8 @@ with the following command:
 ::
 
     git clone http://github.com/carlos-jenkins/python-github-webhooks.git
-    docker build -t carlos-jenkins/python-github-webhooks python-github-webhooks
+    cd python-github-webhooks
+    make
     docker run -d --name webhooks -p 5000:5000 carlos-jenkins/python-github-webhooks
 
 You can also mount volume to setup the ``hooks/`` directory, and the file


### PR DESCRIPTION
By default, `make` pulls base image before building `latest`.

The `docker-build-push` target builds and pushes not only `latest` but also a tagged image, which is always useful for production.
(BTW, there's no https://hub.docker.com/r/carlos-jenkins/python-github-webhooks/ repository)