### PR TITLE
Snap packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+parts
+prime
+stage
+snap/.snapcraft

--- a/snap/scripts/run.sh
+++ b/snap/scripts/run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if [ ! -f "$SNAP_USER_COMMON/config.json" ]; then
+    cp "$SNAP/config.json.sample" "$SNAP_USER_COMMON/config.json"
+fi
+
+if [ ! -L "$SNAP_USER_COMMON/webhooks.py" ]; then
+    ln -sf "$SNAP/webhooks.py" "$SNAP_USER_COMMON"
+fi
+
+if [ "X$SNAP_ARCH" = "Xamd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "X$SNAP_ARCH" = "Xarmhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "X$SNAP_ARCH" = "Xarm64" ]; then
+  ARCH="aarch64-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+export PATH=$SNAP/usr/bin:$PATH
+export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$SNAP/usr/lib:$LD_LIBRARY_PATH
+
+cd "$SNAP_USER_COMMON"
+mkdir -p hooks
+
+exec env $SNAP/usr/bin/python3 ./webhooks.py $@

--- a/snap/scripts/run.sh
+++ b/snap/scripts/run.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ ! -f "$SNAP_USER_COMMON/config.json" ]; then
-    cp "$SNAP/config.json.sample" "$SNAP_USER_COMMON/config.json"
+if [ ! -f "$SNAP_COMMON/config.json" ]; then
+    cp "$SNAP/config.json.sample" "$SNAP_COMMON/config.json"
 fi
 
-if [ ! -L "$SNAP_USER_COMMON/webhooks.py" ]; then
-    ln -sf "$SNAP/webhooks.py" "$SNAP_USER_COMMON"
+if [ ! -L "$SNAP_COMMON/webhooks.py" ]; then
+    ln -sf "$SNAP/webhooks.py" "$SNAP_COMMON"
 fi
 
 if [ "X$SNAP_ARCH" = "Xamd64" ]; then
@@ -21,7 +21,7 @@ fi
 export PATH=$SNAP/usr/bin:$PATH
 export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$SNAP/usr/lib:$LD_LIBRARY_PATH
 
-cd "$SNAP_USER_COMMON"
+cd "$SNAP_COMMON"
 mkdir -p hooks
 
 exec env $SNAP/usr/bin/python3 ./webhooks.py $@

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: python-github-webhooks
+version: git
+summary: Simple Python WSGI application to handle Github webhooks
+description: |
+  Simple Python WSGI application to handle Github webhooks
+
+grade: stable
+confinement: strict
+
+parts:
+  python-github-webhooks:
+    plugin: python
+    requirements: requirements.txt
+    source: .
+    override-build: |
+      snapcraftctl build
+      install -m 755 webhooks.py $SNAPCRAFT_PART_INSTALL
+      install -m 644 config.json.sample $SNAPCRAFT_PART_INSTALL
+      ln -s python3 $SNAPCRAFT_PART_INSTALL/usr/bin/python || true
+    stage-packages:
+     - git
+
+  runner:
+    plugin: dump
+    source: snap/scripts
+    organize:
+      webhooks: bin/run.sh
+
+apps:
+  python-github-webhooks:
+    command: ./run.sh
+    plugs:
+      - network
+      - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,7 @@ parts:
 apps:
   python-github-webhooks:
     command: ./run.sh
+    daemon: simple
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
Add [snap packaging](http://snapcraft.io/) support.

Once merged, you should release this to snapcraft store so that any user could easily benefit from it.
Configuration is saved in `$SNAP_COMMON`.

Probably should added an env variable to define the default path than using workarounds in `run.sh`.